### PR TITLE
Ep76 add org scp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".githooks"]
+	path = .githooks
+	url = https://github.com/burendouk/burendo-githooks

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".githooks"]
-	path = .githooks
-	url = https://github.com/burendouk/burendo-githooks

--- a/scp.tf
+++ b/scp.tf
@@ -1,0 +1,18 @@
+locals {
+  organization_policy_full_access_id = "p-FullAWSAccess"
+}
+
+resource "aws_organizations_policy_attachment" "infrastructure" {
+  policy_id = local.organization_policy_full_access_id
+  target_id = aws_organizations_organizational_unit.infrastructure.id
+}
+
+resource "aws_organizations_policy_attachment" "security" {
+  policy_id = local.organization_policy_full_access_id
+  target_id = aws_organizations_organizational_unit.security.id
+}
+
+resource "aws_organizations_policy_attachment" "management" {
+  policy_id = local.organization_policy_full_access_id
+  target_id = aws_organizations_account.burendo.id
+}


### PR DESCRIPTION
- Import AWS-Managed SCP (FullAWSAccess).
- refer as `local` as it can not be kept in state.
- Import attachments to Ou's and `management` account.