### PR TITLE
EP-109 Add iam account alias for mgmt account

### DIFF
--- a/env-accounts.tf
+++ b/env-accounts.tf
@@ -24,3 +24,7 @@ resource "aws_organizations_account" "burendo" {
   email = lookup(local.email, "burendo-mgmt")
   tags  = merge(local.tags, { Name = "Burendo" })
 }
+
+resource "aws_iam_account_alias" "alias" {
+  account_alias = "burendo-mgmt"
+}


### PR DESCRIPTION

Adding the IAM account alias for the `burendo-mgmt` account.